### PR TITLE
Adding chokidar env variable to allow for rebuilding.

### DIFF
--- a/.docksal/commands/init
+++ b/.docksal/commands/init
@@ -44,6 +44,7 @@ if [[ -d "${PROJECT_ROOT}/gatsby/public" ]]; then
   echo -e "${green} Static site exists, but since we're installing a new Drupal instance, it's got to go...${NC}"
   rm -rf ${PROJECT_ROOT}/gatsby/public
   rm -rf ${PROJECT_ROOT}/gatsby/.cache
+  rm -rf ${PROJECT_ROOT}/gatsby/node_modules
 fi
 
 container_user="-u docker" fin exec --in=gatsby bash -lc "npm install"

--- a/.docksal/docksal.yml
+++ b/.docksal/docksal.yml
@@ -15,6 +15,7 @@ services:
     environment:
       - HOST_UID
       - HOST_GID
+      - CHOKIDAR_USEPOLLING=1
     working_dir: /var/www/gatsby
     dns:
       - ${DOCKSAL_DNS1}

--- a/gatsby/package-lock.json
+++ b/gatsby/package-lock.json
@@ -6077,7 +6077,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6095,11 +6096,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6112,15 +6115,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6223,7 +6229,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6233,6 +6240,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6245,17 +6253,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6272,6 +6283,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6344,7 +6356,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6354,6 +6367,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6429,7 +6443,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6459,6 +6474,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6476,6 +6492,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6514,11 +6531,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
Adds an environment variable to the gatsby service so that chokidar can watch for file changes to get around the fsnotify problem in Docker in a VM.